### PR TITLE
Use correct linux distribution names

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -137,13 +137,13 @@ jobs:
           echo "matrix.linux: ${{ matrix.linux }}"
           echo "matrix.configuration: ${{ matrix.configuration }}"
     - name: Install apt-get Dependencies
-      if: matrix.linux != 'centos' && matrix.linux != 'amazonlinux' && inputs.aptgetdependencies != ''
+      if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && inputs.aptgetdependencies != ''
       run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.aptgetdependencies }}
     - name: Install yum Dependencies
-      if: matrix.linux == 'amazonlinux' && inputs.yumdependencies != ''
+      if: matrix.linux == 'amazonlinux2' && inputs.yumdependencies != ''
       run: yum update -y && yum install -y ${{ inputs.yumdependencies }}
     - name: Install yum Dependencies
-      if: matrix.linux == 'centos' && inputs.yumdependencies != ''
+      if: matrix.linux == 'centos8' && inputs.yumdependencies != ''
       run: yum update -y --nobest && yum install -y ${{ inputs.yumdependencies }}
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
# Use correct linux distribution names

## :recycle: Current situation & Problem
The conditions for installing yum dependencies use the slightly incorrect `centos` and `amazonlinux` matrix values, whereas they should use `centos8` and `amazonlinux2`.

### Related PRs
Currently blocks [Apodini/ApodiniObservePrometheus#7](https://github.com/Apodini/ApodiniObservePrometheus/pull/1).

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
