### PR TITLE
Update GitHub Actions with the release of Xcode 13.2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,22 +68,16 @@ jobs:
       run: swift build -c release
     - name: Release Build & Test
       if: matrix.configuration == 'release_testing'
-      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING -Xlinker -rpath -Xlinker "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
+      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
     - name: Debug Build & Test
       if: matrix.configuration == 'debug'
-      run: swift test -c debug --enable-code-coverage -Xswiftc -DCOVERAGE -Xlinker -rpath -Xlinker "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
+      run: swift test -c debug --enable-code-coverage -Xswiftc -DCOVERAGE
     - name: Convert coverage report
       if: matrix.configuration == 'debug'
       run: xcrun llvm-cov export -format="lcov" .build/debug/${{ inputs.packagename }}PackageTests.xctest/Contents/MacOS/${{ inputs.packagename }}PackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
     - name: Upload coverage to Codecov
       if: matrix.configuration == 'debug'
       uses: codecov/codecov-action@v2
-    - name: Test Generating Docs
-      if: matrix.configuration == 'debug' && inputs.testdocc == true
-      run: |
-          xcodebuild docbuild -scheme ${{ inputs.packagename }} -destination platform=macOS -derivedDataPath ./.xcodebuild
-          cp -r $(find ./.xcodebuild -type d -name '${{ inputs.packagename }}.doccarchive') ./${{ inputs.packagename }}.doccarchive
-          echo "The DocC archive can be found at ./${{ inputs.packagename }}.doccarchive"
   linux:
     name: Linux ${{ matrix.linux }} ${{ matrix.configuration }}
     container:
@@ -131,3 +125,32 @@ jobs:
     - name: Debug Build & Test
       if: matrix.configuration == 'debug'
       run: swift test -c debug
+  generate-docs:
+    name: Generate Docs
+    if: inputs.testdocc == true
+    runs-on: macos-11
+    defaults:
+      run:
+        working-directory: ${{ inputs.path }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: maxim-lobanov/setup-xcode@v1.4.0
+      with:
+        xcode-version: latest
+    - name: Check Environment
+      run: |
+          xcodebuild -version
+          swift --version
+          echo "inputs.packagename: ${{ inputs.packagename }}"
+          echo "inputs.path: ${{ inputs.path }}"
+          echo "inputs.testdocc: ${{ inputs.testdocc }}"
+          echo "cache key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+    - uses: actions/cache@v2
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    - name: Test Generating Docs
+      run: |
+          xcodebuild docbuild -scheme ${{ inputs.packagename }} -destination platform=macOS -derivedDataPath ./.xcodebuild
+          cp -r $(find ./.xcodebuild -type d -name '${{ inputs.packagename }}.doccarchive') ./${{ inputs.packagename }}.doccarchive
+          echo "The DocC archive can be found at ./${{ inputs.packagename }}.doccarchive"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linux: [bionic, focal, amazonlinux2, centos8]
+        linux: [focal, amazonlinux2, centos8]
         configuration: [debug, release, release_testing]
     defaults:
       run:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: '.'
+      supportsmacos11:
+        description: 'Defines if the Swift Package supports macOS 11, the latest version currently available on GitHub Actions Virtual Environments'
+        required: false
+        type: boolean
+        default: true
       testdocc:
         description: 'A flag indicating if the DocC documentation building should be tested'
         required: false
@@ -42,6 +47,7 @@ on:
 jobs:
   macos:
     name: macOS ${{ matrix.configuration }}
+    if: inputs.supportsmacos11
     runs-on: macos-11
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,7 +151,8 @@ jobs:
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
     - name: Test Generating Docs
       run: |
-          xcodebuild -resolvePackageDependencies
-          xcodebuild docbuild -scheme ${{ inputs.packagename }} -destination platform=macOS -derivedDataPath ./.xcodebuild
-          cp -r $(find ./.xcodebuild -type d -name '${{ inputs.packagename }}.doccarchive') ./${{ inputs.packagename }}.doccarchive
+          rm -rf ~/.xcodebuild 
+          mkdir ~/.xcodebuild
+          xcodebuild docbuild -scheme ${{ inputs.packagename }} -destination platform=macOS -derivedDataPath ~/.xcodebuild
+          cp -r $(find ~/.xcodebuild -type d -name '${{ inputs.packagename }}.doccarchive') ./${{ inputs.packagename }}.doccarchive
           echo "The DocC archive can be found at ./${{ inputs.packagename }}.doccarchive"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,14 +112,14 @@ jobs:
           echo "matrix.configuration: ${{ matrix.configuration }}"
           echo "cache key: ${{ runner.os }}-${{matrix.linux}}-spm-${{ hashFiles('Package.resolved') }}"
     - name: Install apt-get Dependencies
-      if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && inputs.aptgetdependencies != ''
-      run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.aptgetdependencies }}
+      if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && (inputs.aptgetdependencies != '' || inputs.installgrpcurl)
+      run: apt-get update && apt-get install -y --no-install-recommends wget ${{ inputs.aptgetdependencies }}
     - name: Install yum Dependencies
-      if: matrix.linux == 'amazonlinux2' && inputs.yumdependencies != ''
-      run: yum update -y && yum install -y ${{ inputs.yumdependencies }}
+      if: matrix.linux == 'amazonlinux2' && (inputs.yumdependencies != '' || inputs.installgrpcurl)
+      run: yum update -y && yum install -y wget ${{ inputs.yumdependencies }}
     - name: Install yum Dependencies
-      if: matrix.linux == 'centos8' && inputs.yumdependencies != ''
-      run: yum update -y --nobest && yum install -y ${{ inputs.yumdependencies }}
+      if: matrix.linux == 'centos8' && (inputs.yumdependencies != '' || inputs.installgrpcurl)
+      run: yum update -y --nobest && yum install -y wget ${{ inputs.yumdependencies }}
     - name: Install grpcurl
       if: inputs.installgrpcurl
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,11 @@ on:
         description: 'Dependencies that must be installed using yum before builds on Amazon Linux and CentOS'
         required: false
         type: string
+      installgrpcurl:
+        description: 'A flag indicating if grpcurl should be installed'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   macos:
@@ -59,6 +64,9 @@ jobs:
           echo "inputs.testdocc: ${{ inputs.testdocc }}"
           echo "matrix.configuration: ${{ matrix.configuration }}"
           echo "cache key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+    - name: Install grpcurl
+      if: inputs.installgrpcurl
+      run: brew install grpcurl
     - uses: actions/cache@v2
       with:
         path: .build
@@ -112,6 +120,12 @@ jobs:
     - name: Install yum Dependencies
       if: matrix.linux == 'centos8' && inputs.yumdependencies != ''
       run: yum update -y --nobest && yum install -y ${{ inputs.yumdependencies }}
+    - name: Install grpcurl
+      if: inputs.installgrpcurl
+      run: |
+        wget 'https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8.5_linux_x86_64.tar.gz'
+        tar -zxvf grpcurl_1.8.5_linux_x86_64.tar.gz grpcurl
+        mv grpcurl /usr/local/bin/
     - uses: actions/cache@v2
       with:
         path: .build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,10 +50,6 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.4.0
       with:
         xcode-version: latest
-    - uses: actions/cache@v2
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
     - name: Check Environment
       run: |
           xcodebuild -version
@@ -62,6 +58,11 @@ jobs:
           echo "inputs.path: ${{ inputs.path }}"
           echo "inputs.testdocc: ${{ inputs.testdocc }}"
           echo "matrix.configuration: ${{ matrix.configuration }}"
+          echo "cache key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+    - uses: actions/cache@v2
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
     - name: Release Build
       if: matrix.configuration == 'release'
       run: swift build -c release
@@ -107,6 +108,7 @@ jobs:
           echo "inputs.yumdependencies: ${{ inputs.yumdependencies }}"
           echo "matrix.linux: ${{ matrix.linux }}"
           echo "matrix.configuration: ${{ matrix.configuration }}"
+          echo "cache key: ${{ runner.os }}-${{matrix.linux}}-spm-${{ hashFiles('Package.resolved') }}"
     - name: Install apt-get Dependencies
       if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && inputs.aptgetdependencies != ''
       run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.aptgetdependencies }}
@@ -120,8 +122,6 @@ jobs:
       with:
         path: .build
         key: ${{ runner.os }}-${{matrix.linux}}-spm-${{ hashFiles('Package.resolved') }}
-    - name: Check Swift version
-      run: swift --version
     - name: Release Build
       if: matrix.configuration == 'release'
       run: swift build -c release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ on:
   workflow_call:
     inputs:
       packagename:
-        description: 'Name of the package e.g., passed ass the scheme to xcodebuild on macOS builds'
+        description: 'Name of the package passed to Xcode on macOS builds. Required for generating a test coverage or testing the DoC documentation generation'
         required: true
         type: string
       path:
@@ -20,15 +20,6 @@ on:
         required: false
         type: string
         default: '.'
-      usexcodebuild: # Remove this option once swift test works using async/await on macOS 11
-        description: 'Testing code containing async/await on macOS 11 currently only works using xcodebuild. This flag indicates if xcodebuild should be used'
-        required: false
-        type: boolean
-        default: true
-      xcodebuildpostfix: # Remove this option once swift test works using async/await on macOS 11
-        description: 'Testing code containing async/await on macOS 11 currently only works using xcodebuild. If you have multiple targets you need to add a postfix like "-Package" to the scheme to test using xcodebuild'
-        required: false
-        type: string
       testdocc:
         description: 'A flag indicating if the DocC documentation building should be tested'
         required: false
@@ -69,37 +60,20 @@ jobs:
           swift --version
           echo "inputs.packagename: ${{ inputs.packagename }}"
           echo "inputs.path: ${{ inputs.path }}"
-          echo "inputs.usexcodebuild: ${{ inputs.usexcodebuild }}"
-          echo "inputs.xcodebuildpostfix: ${{ inputs.xcodebuildpostfix }}"
           echo "inputs.testdocc: ${{ inputs.testdocc }}"
-          echo "inputs.aptgetdependencies: ${{ inputs.aptgetdependencies }}"
-          echo "inputs.yumdependencies: ${{ inputs.yumdependencies }}"
           echo "matrix.configuration: ${{ matrix.configuration }}"
     - name: Release Build
       if: matrix.configuration == 'release'
       run: swift build -c release
-    # Testing code containing async/await on macOS 11 currently only works using xcodebuild, remove the xcodebuild versions once this is fixed.
     - name: Release Build & Test
-      if: matrix.configuration == 'release_testing' && inputs.usexcodebuild == false
-      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
+      if: matrix.configuration == 'release_testing'
+      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING -Xlinker -rpath -Xlinker "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
     - name: Debug Build & Test
-      if: matrix.configuration == 'debug' && inputs.usexcodebuild == false
-      run: swift test -c debug --enable-code-coverage -Xswiftc -DCOVERAGE
+      if: matrix.configuration == 'debug'
+      run: swift test -c debug --enable-code-coverage -Xswiftc -DCOVERAGE -Xlinker -rpath -Xlinker "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
     - name: Convert coverage report
-      if: matrix.configuration == 'debug' && inputs.usexcodebuild == false
+      if: matrix.configuration == 'debug'
       run: xcrun llvm-cov export -format="lcov" .build/debug/${{ inputs.packagename }}PackageTests.xctest/Contents/MacOS/${{ inputs.packagename }}PackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
-    - name: Release Build & Test using xcodebuild
-      if: matrix.configuration == 'release_testing' && inputs.usexcodebuild == true
-      run: xcodebuild -scheme ${{ inputs.packagename }}${{ inputs.xcodebuildpostfix }} -destination platform=macOS -configuration release 'OTHER_SWIFT_FLAGS=-enable-testing -D RELEASE_TEST' test
-    - name: Debug Build & Test using xcodebuild
-      if: matrix.configuration == 'debug' && inputs.usexcodebuild == true
-      run: xcodebuild -scheme ${{ inputs.packagename }}${{ inputs.xcodebuildpostfix }} -destination platform=macOS -configuration debug -enableCodeCoverage YES -derivedDataPath ./.xcodebuild 'OTHER_SWIFT_FLAGS=-D COVERAGE' test
-    - name: Convert coverage report after using xcodebuild
-      if: matrix.configuration == 'debug' && inputs.usexcodebuild == true
-      run: |
-          XCTESTPATH=./.xcodebuild/Build/Products/debug/${{ inputs.packagename }}Tests.xctest/Contents/MacOS/${{ inputs.packagename }}Tests
-          COVERAGEDATA=$(find ./.xcodebuild -type f -name "Coverage.profdata")
-          xcrun llvm-cov export -format="lcov" $XCTESTPATH -instr-profile $COVERAGEDATA > coverage.lcov
     - name: Upload coverage to Codecov
       if: matrix.configuration == 'debug'
       uses: codecov/codecov-action@v2
@@ -129,9 +103,6 @@ jobs:
           swift --version
           echo "inputs.packagename: ${{ inputs.packagename }}"
           echo "inputs.path: ${{ inputs.path }}"
-          echo "inputs.usexcodebuild: ${{ inputs.usexcodebuild }}"
-          echo "inputs.xcodebuildpostfix: ${{ inputs.xcodebuildpostfix }}"
-          echo "inputs.testdocc: ${{ inputs.testdocc }}"
           echo "inputs.aptgetdependencies: ${{ inputs.aptgetdependencies }}"
           echo "inputs.yumdependencies: ${{ inputs.yumdependencies }}"
           echo "matrix.linux: ${{ matrix.linux }}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,6 +151,7 @@ jobs:
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
     - name: Test Generating Docs
       run: |
+          xcodebuild -resolvePackageDependencies
           xcodebuild docbuild -scheme ${{ inputs.packagename }} -destination platform=macOS -derivedDataPath ./.xcodebuild
           cp -r $(find ./.xcodebuild -type d -name '${{ inputs.packagename }}.doccarchive') ./${{ inputs.packagename }}.doccarchive
           echo "The DocC archive can be found at ./${{ inputs.packagename }}.doccarchive"

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -13,7 +13,7 @@ on:
     inputs:
       docker-file:
         description: 'Path or name of the Docker file. The default values is `Dockerfile`. The docker file can use the `baseimage` to get an architecture specific Swift base image'
-        required: true
+        required: false
         type: string
         default: 'Dockerfile'
       image-name:

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -75,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./${{ inputs.docker-file }}
+          file: ${{ inputs.docker-file }}
           build-args: |
             baseimage=${{ steps.baseimage.outputs.value }}
           push: true

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,0 +1,114 @@
+#
+# This source file is part of the Apodini open source project
+#
+# SPDX-FileCopyrightText: 2021 Paul Schmiedmayer and the project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      docker-file:
+        description: 'Path or name of the Docker file. The default values is `Dockerfile`. The docker file can use the `baseimage` to get an architecture specific Swift base image'
+        required: true
+        type: string
+        default: 'Dockerfile'
+      image-name:
+        description: 'The name used to tag the docker image on ghcr.io containing the organzation/account name and the name of the image, e.g.: apodini/example'
+        required: true
+        type: string
+      working-directory:
+        description: 'The working-directory of the GitHub Action. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
+
+jobs:
+  docker:
+    name: Docker Build and Push Image ${{ matrix.architecture }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [arm64, amd64]
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Get latest tag
+        id: latesttag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: latest
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/${{ matrix.architecture }}
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.image-name }}
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Determine Base Image
+        uses: haya14busa/action-cond@v1
+        id: baseimage
+        with:
+          cond: ${{ matrix.architecture == 'arm64' }}
+          if_true: 'swiftarm/swift:5.5.1-ubuntu-focal'
+          if_false: 'swift:focal'
+      - name: Build and push docker image
+        id: buildandpush
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ ${{ inputs.docker-file }}
+          build-args: |
+            baseimage=${{ steps.baseimage.outputs.value }}
+          push: true
+          platforms: linux/${{ matrix.architecture }}
+          tags: ghcr.io/${{ inputs.image-name }}:latest-${{ matrix.architecture }},ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-${{ matrix.architecture }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Image digest
+        run: echo ${{ steps.buildandpush.outputs.digest }}
+  dockermanifest:
+    needs: [docker]
+    name: Create Multi-CPU Architecture Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Get latest tag
+        id: latesttag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: latest
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and Push Multi Architecture Image
+        run: |
+            docker manifest create ghcr.io/${{ inputs.image-name }}:latest \
+              --amend ghcr.io/${{ inputs.image-name }}:latest-amd64 \
+              --amend ghcr.io/${{ inputs.image-name }}:latest-arm64
+            docker manifest create ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }} \
+              --amend ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-amd64 \
+              --amend ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}-arm64
+            docker manifest push ghcr.io/${{ inputs.image-name }}:latest
+            docker manifest push ghcr.io/${{ inputs.image-name }}:${{ steps.latesttag.outputs.tag }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -75,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./ ${{ inputs.docker-file }}
+          file: ./${{ inputs.docker-file }}
           build-args: |
             baseimage=${{ steps.baseimage.outputs.value }}
           push: true

--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -42,7 +42,7 @@ jobs:
         if: inputs.testscript != ''
         run: |
           sleep 5
-          sh ${{ inputs.working-directory }}/${{ inputs.testscript }}
+          sh ${{ inputs.testscript }}
       - name: Docker compose down
         if: always()
         run: docker-compose down

--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -13,7 +13,7 @@ on:
     inputs:
       docker-compose-file:
         description: 'Path or name of the Docker compose file. The default values is `docker-compose-development.yml`'
-        required: true
+        required: false
         type: string
         default: 'docker-compose-development.yml'
       working-directory:

--- a/.github/workflows/docker-compose-test.yml
+++ b/.github/workflows/docker-compose-test.yml
@@ -1,0 +1,48 @@
+#
+# This source file is part of the Apodini open source project
+#
+# SPDX-FileCopyrightText: 2021 Paul Schmiedmayer and the project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Docker Compose
+
+on:
+  workflow_call:
+    inputs:
+      docker-compose-file:
+        description: 'Path or name of the Docker compose file. The default values is `docker-compose-development.yml`'
+        required: true
+        type: string
+        default: 'docker-compose-development.yml'
+      working-directory:
+        description: 'The working-directory of the GitHub Action. Defaults to $GITHUB_WORKSPACE'
+        required: false
+        type: string
+        default: '.'
+      testscript:
+        description: 'Optional path or name to a test script to test the Docker compose setup'
+        required: false
+        type: string
+
+jobs:
+  buildandtest:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker compose up
+        run: docker-compose -f ${{ inputs.working-directory }}/${{ inputs.docker-compose-file }} up -d --build
+      - name: Run test script
+        if: inputs.testscript != ''
+        run: |
+          sleep 5
+          sh ${{ inputs.working-directory }}/${{ inputs.testscript }}
+      - name: Docker compose down
+        if: always()
+        run: docker-compose down

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ on:
   workflow_call:
     inputs:
       packagename:
-        description: 'Name of the package e.g., passed ass the scheme to xcodebuild on macOS builds'
+        description: 'Name of the package e.g., passed as the scheme to xcodebuild on macOS builds'
         required: true
         type: string
 

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,7 +16,7 @@ jobs:
     name: SwiftLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
         with:

--- a/SetupARMGitHubRunner.sh
+++ b/SetupARMGitHubRunner.sh
@@ -1,0 +1,48 @@
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+
+
+# Setup Swap based of https://bogdancornianu.com/change-swap-size-in-ubuntu/
+
+sudo fallocate -l 2G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile swap swap defaults 0 0' | sudo tee -a /etc/fstab
+sudo swapon --show
+
+
+# Install Docker
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install linux-modules-extra-raspi ca-certificates curl gnupg lsb-release
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo DEBIAN_FRONTEND=noninteractive gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install docker-ce docker-ce-cli containerd.io
+
+sudo groupadd docker
+sudo usermod -aG docker $USER
+docker --version
+
+sudo systemctl enable docker.service
+sudo systemctl enable containerd.service
+
+
+# Schedule Restart and Clean Every Day
+
+sudo crontab -l > restartandclean
+echo "0 4 * * * shutdown -r now" >> restartandclean
+echo "0 4 * * * rm -rf /home/ubuntu/actions-runner/_work" >> restartandclean
+crontab restartandclean
+rm restartandclean
+
+
+# Reboot
+
+sudo systemctl reboot


### PR DESCRIPTION
# Update GitHub Actions with the release of Xcode 13.2

## :recycle: Current situation & Problem

As noted in https://github.com/Apodini/Apodini/pull/374 Xcode 13.2 includes to support to run and test code with Swift Concurrency on macOS 11. This PR adapts the GitHub Actions to use `swift build` without `xcodebuild` to reflect the latest advancements made in Xcode 13.2 RC.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
