### PR TITLE
Remove centos8 from build matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linux: [focal, amazonlinux2, centos8]
+        linux: [focal, amazonlinux2]
         configuration: [debug, release, release_testing]
     defaults:
       run:


### PR DESCRIPTION
CentOS 8 has [reached its end of life](https://www.centos.org/centos-linux-eol/), and does no longer work in GitHub runners.

As such, it should be removed from the build matrix
