### PR TITLE
Add homebrew support and 'installprotoc' input

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,15 @@ on:
         required: false
         type: boolean
         default: false
+      homebrewdependencies:
+        description: 'Dependencies that mus be installed using homebrew before builds on macOS'
+        required: false
+        type: string
+      installprotoc:
+        description: 'A flag indicating if protobuf compuler should be installed'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   macos:
@@ -82,6 +91,14 @@ jobs:
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+
+    - name: Set up Homebrew
+      if: inputs.homebrewdependencies != ''
+      uses: Homebrew/actions/setup-homebrew@master
+    - name: Install Homebrew dependencies
+      if: inputs.homebrewdependencies != ''
+      run: brew install ${{ inputs.homebrewdependencies }}
+
     - name: Release Build
       if: matrix.configuration == 'release'
       run: swift build -c release
@@ -127,16 +144,22 @@ jobs:
       run: apt-get update && apt-get install -y --no-install-recommends wget ${{ inputs.aptgetdependencies }}
     - name: Install yum Dependencies
       if: matrix.linux == 'amazonlinux2' && (inputs.yumdependencies != '' || inputs.installgrpcurl)
-      run: yum update -y && yum install -y wget ${{ inputs.yumdependencies }}
+      run: yum update -y && yum install -y wget unzip ${{ inputs.yumdependencies }}
     - name: Install yum Dependencies
       if: matrix.linux == 'centos8' && (inputs.yumdependencies != '' || inputs.installgrpcurl)
-      run: yum update -y --nobest && yum install -y wget ${{ inputs.yumdependencies }}
+      run: yum update -y --nobest && yum install -y wget unzip ${{ inputs.yumdependencies }}
     - name: Install grpcurl
       if: inputs.installgrpcurl
       run: |
         wget 'https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8.5_linux_x86_64.tar.gz'
         tar -zxvf grpcurl_1.8.5_linux_x86_64.tar.gz grpcurl
         mv grpcurl /usr/local/bin/
+    - name: Install protoc
+      if: inputs.installprotoc
+      run: |
+        wget 'https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip'
+        unzip protoc-3.19.4-linux-x86_64.zip
+        mv bin/protoc /usr/local/bin
     - uses: actions/cache@v2
       with:
         path: .build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,20 +84,19 @@ jobs:
           echo "inputs.testdocc: ${{ inputs.testdocc }}"
           echo "matrix.configuration: ${{ matrix.configuration }}"
           echo "cache key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+    - name: Install Homebrew dependencies
+      if: inputs.homebrewdependencies != ''
+      run: brew install ${{ inputs.homebrewdependencies }}
     - name: Install grpcurl
       if: inputs.installgrpcurl
       run: brew install grpcurl
+    - name: Install protoc
+      if: inputs.installprotoc
+      run: brew install protobuf
     - uses: actions/cache@v2
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-
-    - name: Set up Homebrew
-      if: inputs.homebrewdependencies != ''
-      uses: Homebrew/actions/setup-homebrew@master
-    - name: Install Homebrew dependencies
-      if: inputs.homebrewdependencies != ''
-      run: brew install ${{ inputs.homebrewdependencies }}
 
     - name: Release Build
       if: matrix.configuration == 'release'
@@ -140,13 +139,13 @@ jobs:
           echo "matrix.configuration: ${{ matrix.configuration }}"
           echo "cache key: ${{ runner.os }}-${{matrix.linux}}-spm-${{ hashFiles('Package.resolved') }}"
     - name: Install apt-get Dependencies
-      if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && (inputs.aptgetdependencies != '' || inputs.installgrpcurl)
+      if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && (inputs.aptgetdependencies != '' || inputs.installgrpcurl || inputs.installprotoc)
       run: apt-get update && apt-get install -y --no-install-recommends wget ${{ inputs.aptgetdependencies }}
     - name: Install yum Dependencies
-      if: matrix.linux == 'amazonlinux2' && (inputs.yumdependencies != '' || inputs.installgrpcurl)
+      if: matrix.linux == 'amazonlinux2' && (inputs.yumdependencies != '' || inputs.installgrpcurl || inputs.installprotoc)
       run: yum update -y && yum install -y wget unzip ${{ inputs.yumdependencies }}
     - name: Install yum Dependencies
-      if: matrix.linux == 'centos8' && (inputs.yumdependencies != '' || inputs.installgrpcurl)
+      if: matrix.linux == 'centos8' && (inputs.yumdependencies != '' || inputs.installgrpcurl || inputs.installprotoc)
       run: yum update -y --nobest && yum install -y wget unzip ${{ inputs.yumdependencies }}
     - name: Install grpcurl
       if: inputs.installgrpcurl


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Add homebrew support and 'installprotoc' input

## :recycle: Current situation & Problem
The test suite of `ApodiniMigrator` requires `protoc` to be installed for a full end to end test.

## :bulb: Proposed solution
This PR adds support for installing protoc by installing via `brew` or via direct GitHub release download (dependency managers maintain a version which is too old for us)

## :gear: Release Notes 
* Added input for `build_and_test` to install `protobuf-compiler` package

## :heavy_plus_sign: Additional Information

### Related PRs
- Required by https://github.com/Apodini/ApodiniMigrator/pull/11

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
