### PR TITLE
Fix `installprotoc` input

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -158,7 +158,8 @@ jobs:
       run: |
         wget 'https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip'
         unzip protoc-3.19.4-linux-x86_64.zip
-        mv bin/protoc /usr/local/bin
+        mv bin /usr/local
+        mv include /usr/local
     - uses: actions/cache@v2
       with:
         path: .build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -140,7 +140,7 @@ jobs:
           echo "cache key: ${{ runner.os }}-${{matrix.linux}}-spm-${{ hashFiles('Package.resolved') }}"
     - name: Install apt-get Dependencies
       if: matrix.linux != 'centos8' && matrix.linux != 'amazonlinux2' && (inputs.aptgetdependencies != '' || inputs.installgrpcurl || inputs.installprotoc)
-      run: apt-get update && apt-get install -y --no-install-recommends wget ${{ inputs.aptgetdependencies }}
+      run: apt-get update && apt-get install -y --no-install-recommends wget unzip ${{ inputs.aptgetdependencies }}
     - name: Install yum Dependencies
       if: matrix.linux == 'amazonlinux2' && (inputs.yumdependencies != '' || inputs.installgrpcurl || inputs.installprotoc)
       run: yum update -y && yum install -y wget unzip ${{ inputs.yumdependencies }}


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix `installprotoc` input

## :recycle: Current situation & Problem
There are two issues with `installprotoc` which I have overlooked:
* `unzip` is not installed on `apt-get` platforms resulting in a failed installation
* The well known proto types (like timestamp or empty) aren't copied from the zip file into a `include` directory.

## :bulb: Proposed solution
This PR fixes both issues.

## :gear: Release Notes 
* Fixes an issue where `installprotoc` wouldn't succeed on `apt`-managed platforms
* Fixes an issue where protoc well known types were unavailable on linux platforms

## :heavy_plus_sign: Additional Information
macOS installation worked as expected.

### Related PRs
Introduced via #10.

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
