### PR TITLE
Fix git Safe Directory CSV-related Bug

### DIFF
--- a/.github/workflows/spm-update.yml
+++ b/.github/workflows/spm-update.yml
@@ -38,7 +38,7 @@ jobs:
       image: swift:focal
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check Environment
       run: |
           swift --version
@@ -47,7 +47,9 @@ jobs:
           echo "inputs.branch: ${{ inputs.branch }}"
     - name: Update Swift Packages
       run: swift package update
-    - uses: peter-evans/create-pull-request@v3
+    - name: Add Safe Directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.token }}
         commit-message: Update dependencies


### PR DESCRIPTION
# Fix git Safe Directory CSV-related Bug

## :recycle: Current situation & Problem
The GitHub Action to run a Swift Package Manager update fails related to the [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) when pushing using the create PR GitHub Action.

## :bulb: Proposed solution
This PR updates the GitHub Action to work again. The issue is related to the [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) and adds the GitHub Workspace as a safe directory before the create PR GitHub Action is called. 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
